### PR TITLE
Fix stack argument in audio delay revert utility

### DIFF
--- a/dia/audio.py
+++ b/dia/audio.py
@@ -171,7 +171,7 @@ def build_revert_indices(B: int, T: int, C: int, delay_pattern: tp.List[int]) ->
             t_idx_BxTxC.reshape(-1),
             c_idx_BxTxC.reshape(-1),
         ],
-        axis=1,
+        dim=1,
     ).long()  # Ensure indices are long type
 
     return t_idx_BxTxC, indices_BTCx3


### PR DESCRIPTION
## Summary
- fix invalid argument for `torch.stack` in `build_revert_indices`

## Testing
- `python -m py_compile dia/audio.py`
- `ruff check .`
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_68401f53aa1c8331bba536fe1a111791