### PR TITLE
Fix GitHub spelling in docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ from dia.model import Dia
 
 model = Dia.from_pretrained("nari-labs/Dia-1.6B")
 
-text = "[S1] Dia is an open weights text to dialogue model. [S2] You get full control over scripts and voices. [S1] Wow. Amazing. (laughs) [S2] Try it now on Git hub or Hugging Face."
+ text = "[S1] Dia is an open weights text to dialogue model. [S2] You get full control over scripts and voices. [S1] Wow. Amazing. (laughs) [S2] Try it now on GitHub or Hugging Face."
 
 output = model.generate(text)
 

--- a/app.py
+++ b/app.py
@@ -232,7 +232,7 @@ css = """
 #col-container {max-width: 90%; margin-left: auto; margin-right: auto;}
 """
 # Attempt to load default text from example.txt
-default_text = "[S1] Dia is an open weights text to dialogue model. \n[S2] You get full control over scripts and voices. \n[S1] Wow. Amazing. (laughs) \n[S2] Try it now on Git hub or Hugging Face."
+default_text = "[S1] Dia is an open weights text to dialogue model. \n[S2] You get full control over scripts and voices. \n[S1] Wow. Amazing. (laughs) \n[S2] Try it now on GitHub or Hugging Face."
 example_txt_path = Path("./example.txt")
 if example_txt_path.exists():
     try:
@@ -351,7 +351,7 @@ with gr.Blocks(css=css) as demo:
             0.94,
         ],
         [
-            "[S1] Open weights text to dialogue model. \n[S2] You get full control over scripts and voices. \n[S1] I'm biased, but I think we clearly won. \n[S2] Hard to disagree. (laughs) \n[S1] Thanks for listening to this demo. \n[S2] Try it now on Git hub and Hugging Face. \n[S1] If you liked our model, please give us a star and share to your friends. \n[S2] This was Nari Labs.",
+            "[S1] Open weights text to dialogue model. \n[S2] You get full control over scripts and voices. \n[S1] I'm biased, but I think we clearly won. \n[S2] Hard to disagree. (laughs) \n[S1] Thanks for listening to this demo. \n[S2] Try it now on GitHub and Hugging Face. \n[S1] If you liked our model, please give us a star and share to your friends. \n[S2] This was Nari Labs.",
             example_prompt_path if Path(example_prompt_path).exists() else None,
             3072,
             3.0,

--- a/example/simple.py
+++ b/example/simple.py
@@ -5,7 +5,7 @@ from dia.model import Dia
 
 model = Dia.from_pretrained("nari-labs/Dia-1.6B")
 
-text = "[S1] Dia is an open weights text to dialogue model. [S2] You get full control over scripts and voices. [S1] Wow. Amazing. (laughs) [S2] Try it now on Git hub or Hugging Face."
+text = "[S1] Dia is an open weights text to dialogue model. [S2] You get full control over scripts and voices. [S1] Wow. Amazing. (laughs) [S2] Try it now on GitHub or Hugging Face."
 
 output = model.generate(text)
 

--- a/example/voice_clone.py
+++ b/example/voice_clone.py
@@ -8,7 +8,7 @@ model = Dia.from_pretrained("nari-labs/Dia-1.6B")
 # You should put the transcript of the voice you want to clone
 # We will use the audio created by running simple.py as an example.
 # Note that you will be REQUIRED TO RUN simple.py for the script to work as-is.
-clone_from_text = "[S1] Dia is an open weights text to dialogue model. [S2] You get full control over scripts and voices. [S1] Wow. Amazing. (laughs) [S2] Try it now on Git hub or Hugging Face."
+clone_from_text = "[S1] Dia is an open weights text to dialogue model. [S2] You get full control over scripts and voices. [S1] Wow. Amazing. (laughs) [S2] Try it now on GitHub or Hugging Face."
 clone_from_audio = "simple.mp3"
 
 # For your custom needs, replace above with below and add your audio file to this directory:


### PR DESCRIPTION
## Summary
- fix GitHub brand capitalization in documentation and example code
- update default text and example text in app

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6840239adaac8331bfb52dd9d68f0379