### PR TITLE
Add config save test

### DIFF
--- a/dia/config.py
+++ b/dia/config.py
@@ -178,7 +178,9 @@ class DiaConfig(BaseModel, frozen=True):
         Raises:
             ValueError: If the path is not a file with a .json extension.
         """
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        dir_name = os.path.dirname(path)
+        if dir_name:
+            os.makedirs(dir_name, exist_ok=True)
         config_json = self.model_dump_json(indent=2)
         with open(path, "w") as f:
             f.write(config_json)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,53 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from dia.config import (
+    DataConfig,
+    DecoderConfig,
+    DiaConfig,
+    EncoderConfig,
+    ModelConfig,
+    TrainingConfig,
+)
+
+
+def minimal_config() -> DiaConfig:
+    return DiaConfig(
+        model=ModelConfig(
+            encoder=EncoderConfig(
+                n_layer=1,
+                n_embd=8,
+                n_hidden=8,
+                n_head=1,
+                head_dim=8,
+            ),
+            decoder=DecoderConfig(
+                n_layer=1,
+                n_embd=8,
+                n_hidden=8,
+                gqa_query_heads=1,
+                kv_heads=1,
+                gqa_head_dim=8,
+                cross_query_heads=1,
+                cross_head_dim=8,
+            ),
+        ),
+        training=TrainingConfig(),
+        data=DataConfig(text_length=128, audio_length=128),
+    )
+
+
+def test_save_without_directory(tmp_path, monkeypatch):
+    cfg = minimal_config()
+    monkeypatch.chdir(tmp_path)
+    path = "tmp_config.json"
+    cfg.save(path)
+    assert os.path.isfile(path)
+    with open(path, "r") as f:
+        json.load(f)
+    os.remove(path)


### PR DESCRIPTION
## Summary
- fix DiaConfig.save to handle file paths without directories
- add regression test verifying DiaConfig.save works for bare file names

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684024048a6883319a164d3b8abea313