### PR TITLE
Improve DiaConfig.save validation

### DIFF
--- a/dia/config.py
+++ b/dia/config.py
@@ -170,15 +170,22 @@ class DiaConfig(BaseModel, frozen=True):
     def save(self, path: str) -> None:
         """Save the current configuration instance to a JSON file.
 
-        Ensures the parent directory exists and the file has a .json extension.
+        Ensures the parent directory exists (if provided) and the file has a
+        ``.json`` extension.
 
         Args:
             path: The target file path to save the configuration.
 
         Raises:
-            ValueError: If the path is not a file with a .json extension.
+            ValueError: If the path is not a file with a ``.json`` extension.
         """
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        if not path.endswith(".json"):
+            raise ValueError("Configuration path must end with '.json'")
+
+        directory = os.path.dirname(path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+
         config_json = self.model_dump_json(indent=2)
         with open(path, "w") as f:
             f.write(config_json)


### PR DESCRIPTION
## Summary
- ensure DiaConfig.save validates `.json` file extension
- only create directories when a parent path is provided

## Testing
- `ruff check`

------
https://chatgpt.com/codex/tasks/task_e_684023be53e883318daeae819d8b07cc