### PR TITLE
Fix DiaConfig.save path validation

### DIFF
--- a/dia/config.py
+++ b/dia/config.py
@@ -170,17 +170,22 @@ class DiaConfig(BaseModel, frozen=True):
     def save(self, path: str) -> None:
         """Save the current configuration instance to a JSON file.
 
-        Ensures the parent directory exists and the file has a .json extension.
+        Ensures the parent directory exists (if provided) and the file has a
+        ``.json`` extension.
 
         Args:
             path: The target file path to save the configuration.
 
         Raises:
-            ValueError: If the path is not a file with a .json extension.
+            ValueError: If the path is not a file with a ``.json`` extension.
         """
+        if not path.endswith(".json"):
+            raise ValueError("Configuration path must end with '.json'")
+
         dir_name = os.path.dirname(path)
         if dir_name:
             os.makedirs(dir_name, exist_ok=True)
+
         config_json = self.model_dump_json(indent=2)
         with open(path, "w") as f:
             f.write(config_json)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,8 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -51,3 +53,19 @@ def test_save_without_directory(tmp_path, monkeypatch):
     with open(path, "r") as f:
         json.load(f)
     os.remove(path)
+
+
+def test_save_with_directory(tmp_path):
+    cfg = minimal_config()
+    path = tmp_path / "dir1" / "config.json"
+    cfg.save(str(path))
+    assert path.is_file()
+    with open(path, "r") as f:
+        json.load(f)
+
+
+def test_save_invalid_extension(tmp_path):
+    cfg = minimal_config()
+    invalid_path = tmp_path / "config.txt"
+    with pytest.raises(ValueError):
+        cfg.save(str(invalid_path))


### PR DESCRIPTION
## Summary
- validate `.json` extension in `DiaConfig.save`
- add tests for directory creation and invalid extension

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845249c5e18833199ec154dba369ef9